### PR TITLE
Added log4j2 and logback tests to embedded TS

### DIFF
--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -38,6 +38,8 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
+        <version.org.apache.logging.log4j>2.11.0</version.org.apache.logging.log4j>
+        <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
     </properties>
 
     <dependencies>
@@ -49,6 +51,35 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-embedded</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${version.org.apache.logging.log4j}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${version.org.apache.logging.log4j}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${version.ch.qos.logback}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${version.ch.qos.logback}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/LoggingTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/LoggingTestCase.java
@@ -149,7 +149,7 @@ public abstract class LoggingTestCase extends AbstractTestCase {
                 System.out.flush();
                 System.err.flush();
                 Assert.assertEquals(String.format("The following messages were found on the console: %n%s", STDOUT.toString()), 0, STDOUT.size());
-                Assert.assertEquals(String.format("The following messages were found on the console: %n%s", STDERR.toString()), 0, STDERR.size());
+                Assert.assertEquals(String.format("The following messages were found on the error console: %n%s", STDERR.toString()), 0, STDERR.size());
             }
         } finally {
             server.stop();

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/Log4j2HostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/Log4j2HostControllerTestCase.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.host.controller;
+
+import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:nziakova@redhat.com">Nikoleta Ziakova</a>
+ */
+public class Log4j2HostControllerTestCase extends LoggingTestCase {
+
+    @Test
+    public void testLog4j2() throws Exception {
+        System.setProperty("test.log.file", "test-hc-log4j2.log");
+        testHostController(Configuration.LoggerHint.LOG4J2, "test-hc-log4j2.log", "[log4j2]");
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/LogbackHostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/LogbackHostControllerTestCase.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.host.controller;
+
+import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:nziakova@redhat.com">Nikoleta Ziakova</a>
+ */
+public class LogbackHostControllerTestCase extends LoggingTestCase {
+
+    @Test
+    public void testLogback() throws Exception {
+        System.setProperty("test.log.file", "test-hc-logback.log");
+        testHostController(Configuration.LoggerHint.LOGBACK, "test-hc-logback.log", "[logback]");
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/Log4j2StandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/Log4j2StandaloneTestCase.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.standalone;
+
+import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:nziakova@redhat.com">Nikoleta Ziakova</a>
+ */
+public class Log4j2StandaloneTestCase extends LoggingTestCase {
+
+    @Test
+    public void testLog4j2() throws Exception {
+        System.setProperty("test.log.file", "test-standalone-log4j2.log");
+        testStandalone(Configuration.LoggerHint.LOG4J2, "test-standalone-log4j2.log", "[log4j2]");
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/LogbackStandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/LogbackStandaloneTestCase.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.standalone;
+
+import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:nziakova@redhat.com">Nikoleta Ziakova</a>
+ */
+public class LogbackStandaloneTestCase extends LoggingTestCase {
+
+    @Test
+    public void testLogback() throws Exception {
+        System.setProperty("test.log.file", "test-standalone-logback.log");
+        testStandalone(Configuration.LoggerHint.LOGBACK, "test-standalone-logback.log", "[logback]");
+    }
+}

--- a/testsuite/embedded/src/test/resources/log4j2-test.properties
+++ b/testsuite/embedded/src/test/resources/log4j2-test.properties
@@ -1,0 +1,30 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2018 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+appenders = file
+
+appender.file.type = File
+appender.file.name = LOGFILE
+appender.file.fileName = ${sys:jboss.test.log.dir}${sys:file.separator}${sys:test.log.file}
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = [log4j2] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+
+rootLogger.appenderRefs = file
+rootLogger.appenderRef.file.ref = LOGFILE
+rootLogger.level = info

--- a/testsuite/embedded/src/test/resources/logback-test.xml
+++ b/testsuite/embedded/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>${jboss.test.log.dir}${file.separator}${test.log.file}</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>[logback] %d{yyyy-MM-dd_HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -144,6 +144,10 @@
                     <groupId>com.fasterxml.woodstox</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.slf4j</groupId>
+                    <artifactId>slf4j-jboss-logmanager</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3205

@jamezp I have added tests for the rest of the log managers which were not added in https://github.com/wildfly/wildfly-core/pull/3202. Could you please take a look and tell if it is okay?

I had to exclude slf4j-jboss-logmanager dependency because with that on classpath the logback test prints following message to console: `SLF4J: Class path contains multiple SLF4J bindings.` If the exclusion is undesired, I think the only solution would be to set `validateConsoleOutput` to `false` for the logback test. I'd like to keep it default if possible, though. WDYT?