### PR TITLE
Scripts enhancements

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/standalone-new.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone-new.sh
@@ -1,72 +1,67 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
 
 # Use --debug to activate debug mode with an optional argument to specify the port.
 # Usage : standalone.sh --debug
 #         standalone.sh --debug 9797
 
 # By default debug mode is disabled.
-DEBUG_MODE="${DEBUG:-false}"
-DEBUG_PORT="${DEBUG_PORT:-8787}"
-GC_LOG="$GC_LOG"
+readonly DEBUG_MODE="${DEBUG:-'false'}"
+readonly DEBUG_PORT="${DEBUG_PORT:-'8787'}"
+readonly GC_LOG="${GC_LOG}"
 
-DIRNAME=`dirname "$0"`
-PROGNAME=`basename "$0"`
-GREP="grep"
+readonly DIRNAME=$(dirname "${0})")
+readonly PROGNAME=$(basename "${0}")
 
 # Use the maximum available, or set MAX_FD != -1 to use that
-MAX_FD="maximum"
+readonly MAX_FD="maximum"
 
 # tell linux glibc how many memory pools can be created that are used by malloc
-MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-1}"
+readonly MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:'-1'}"
 export MALLOC_ARENA_MAX
 
 # OS specific support (must be 'true' or 'false').
-cygwin=false;
-darwin=false;
-linux=false;
-solaris=false;
-freebsd=false;
-other=false
-case "`uname`" in
+case "$(uname)" in
     CYGWIN*)
-        cygwin=true
+        readonly cygwin=true
         ;;
 
     Darwin*)
-        darwin=true
+        readonly darwin=true
         ;;
     FreeBSD)
-        freebsd=true
+        readonly freebsd=true
         ;;
     Linux)
-        linux=true
+        readonly linux=true
         ;;
     SunOS*)
-        solaris=true
+        readonly solaris=true
         ;;
     *)
-        other=true
+        readonly other=true
         ;;
 esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
-if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
-    [ -n "$JAVA_HOME" ] &&
-        JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-    [ -n "$JAVAC_JAR" ] &&
-        JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
+if ${cygwin} ; then
+    [ -n "${JBOSS_HOME}" ] &&
+        JBOSS_HOME=$(cygpath --unix "${JBOSS_HOME}")
+    [ -n "${JAVA_HOME}" ] &&
+        JAVA_HOME=$(cygpath --unix "${JAVA_HOME}")
+    [ -n "${JAVAC_JAR}" ] &&
+        JAVAC_JAR=$(cygpath --unix "${JAVAC_JAR}")
 fi
 
 # Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.." >/dev/null; pwd`
+readonly RESOLVED_JBOSS_HOME=${JBOSS_HOME:-$(cd "$DIRNAME/.." >/dev/null; pwd)}
 if [ "x$JBOSS_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
-else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
+    readonly JBOSS_HOME="${RESOLVED_JBOSS_HOME}"
+else # this below could and should be handle by the launcher no?
+    readonly SANITIZED_JBOSS_HOME=${JBOSS_HOME:-$(cd "$JBOSS_HOME"; pwd)}
+ if [ "${RESOLVED_JBOSS_HOME}" != "${SANITIZED_JBOSS_HOME}" ]; then
    echo ""
    echo "   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
@@ -78,41 +73,41 @@ fi
 export JBOSS_HOME
 
 # Setup the JVM
-if [ "x$JAVA" = "x" ]; then
-    if [ "x$JAVA_HOME" != "x" ]; then
-        JAVA="$JAVA_HOME/bin/java"
+if [ -n "${JAVA}" ]; then
+    if [ -n "${JAVA_HOME}" ]; then
+        JAVA="${JAVA_HOME}/bin/java"
     else
-        JAVA="java"
+        JAVA='java'
     fi
 fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
-    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
-    JBOSS_BASE_DIR=`cygpath --path --windows "$JBOSS_BASE_DIR"`
-    JBOSS_LOG_DIR=`cygpath --path --windows "$JBOSS_LOG_DIR"`
-    JBOSS_CONFIG_DIR=`cygpath --path --windows "$JBOSS_CONFIG_DIR"`
+    JBOSS_HOME=$(cygpath --path --windows "${JBOSS_HOME}")
+    JAVA_HOME=$(cygpath --path --windows "${JAVA_HOME}")
+    JBOSS_MODULEPATH=$(cygpath --path --windows "${JBOSS_MODULEPATH}")
+    JBOSS_BASE_DIR=$(cygpath --path --windows "${JBOSS_BASE_DIR}")
+    JBOSS_LOG_DIR=$(cygpath --path --windows "${JBOSS_LOG_DIR}")
+    JBOSS_CONFIG_DIR=$(cygpath --path --windows "${JBOSS_CONFIG_DIR}")
 fi
 
 while true; do
-   if [ "x$LAUNCH_JBOSS_IN_BACKGROUND" = "x" ]; then
+   if [ -n "${LAUNCH_JBOSS_IN_BACKGROUND}" ]; then
       # Execute the JVM in the foreground
-      eval \"$JAVA\" -cp \"$JBOSS_HOME/bin/launcher.jar\" org.wildfly.core.launcher.StandaloneEntry $@
-      JBOSS_STATUS=$?
+      eval "${JAVA}" -cp "${JBOSS_HOME}/bin/launcher.jar" 'org.wildfly.core.launcher.StandaloneEntry' $@
+      JBOSS_STATUS=${?}
    else
       # Execute the JVM in the background
-      eval \"$JAVA\" -cp \"$JBOSS_HOME/bin/launcher.jar\" org.wildfly.core.launcher.StandaloneEntry $@ \"&\"
-      JBOSS_PID=$!
+      eval "${JAVA}" -cp "${JBOSS_HOME}/bin/launcher.jar" org.wildfly.core.launcher.StandaloneEntry $@ \"&\"
+      JBOSS_PID="${!}"
       # Trap common signals and relay them to the jboss process
-      trap "kill -HUP  $JBOSS_PID" HUP
-      trap "kill -TERM $JBOSS_PID" INT
-      trap "kill -QUIT $JBOSS_PID" QUIT
-      trap "kill -PIPE $JBOSS_PID" PIPE
-      trap "kill -TERM $JBOSS_PID" TERM
-      if [ "x$JBOSS_PIDFILE" != "x" ]; then
-        echo $JBOSS_PID > $JBOSS_PIDFILE
+      trap kill -HUP  "${JBOSS_PID}" HUP
+      trap kill -TERM "${JBOSS_PID}" INT
+      trap kill -QUIT "${JBOSS_PID}" QUIT
+      trap kill -PIPE "${JBOSS_PID}" PIPE
+      trap kill -TERM "${JBOSS_PID}" TERM
+      if [ -n "${JBOSS_PIDFILE}"  ]; then
+        echo "${JBOSS_PID}" > "${JBOSS_PIDFILE}"
       fi
       # Wait until the background process exits
       WAIT_STATUS=128
@@ -120,27 +115,27 @@ while true; do
          wait $JBOSS_PID 2>/dev/null
          WAIT_STATUS=$?
          if [ "$WAIT_STATUS" -gt 128 ]; then
-            SIGNAL=`expr $WAIT_STATUS - 128`
-            SIGNAL_NAME=`kill -l $SIGNAL`
-            echo "*** JBossAS process ($JBOSS_PID) received $SIGNAL_NAME signal ***" >&2
+            SIGNAL=$(expr "${WAIT_STATUS}" - 128)
+            SIGNAL_NAME=$(kill -l "${SIGNAL}")
+            echo "*** JBossAS process (${JBOSS_PID}) received $SIGNAL_NAME signal ***" >&2
          fi
       done
-      if [ "$WAIT_STATUS" -lt 127 ]; then
-         JBOSS_STATUS=$WAIT_STATUS
+      if [ "${WAIT_STATUS}" -lt 127 ]; then
+         JBOSS_STATUS=${WAIT_STATUS}
       else
          JBOSS_STATUS=0
       fi
-      if [ "$JBOSS_STATUS" -ne 10 ]; then
+      if [ "${JBOSS_STATUS}" -ne 10 ]; then
             # Wait for a complete shudown
-            wait $JBOSS_PID 2>/dev/null
+            wait "${JBOSS_PID}" 2>/dev/null
       fi
-      if [ "x$JBOSS_PIDFILE" != "x" ]; then
-            grep "$JBOSS_PID" $JBOSS_PIDFILE && rm $JBOSS_PIDFILE
+      if [ -n "${JBOSS_PIDFILE}" ]; then
+            grep "${JBOSS_PID}" "${JBOSS_PIDFILE}" && rm "${JBOSS_PIDFILE}"
       fi
    fi
-   if [ "$JBOSS_STATUS" -eq 10 ]; then
+   if [ "${JBOSS_STATUS}" -eq 10 ]; then
       echo "Restarting application server..."
    else
-      exit $JBOSS_STATUS
+      exit "${JBOSS_STATUS}"
    fi
 done


### PR DESCRIPTION
@jamezp Here is a few scripts enhacements and cleanup. I've not tested the script but I don't think they changed its behavior (if so, let me know and I'll fix it). I'll comment the changes in the PR to let you know why I did what.

With those changes, [shellcheck](https://www.shellcheck.net/) (PMD/Findbugs for Shell) is almost happy with us:

`
$ shellcheck bin/standalone-new.sh 

In bin/standalone-new.sh line 97:
      eval "${JAVA}" -cp "${JBOSS_HOME}/bin/launcher.jar" 'org.wildfly.core.launcher.StandaloneEntry' $@
                                                                                                      ^-- SC2068: Double quote array expansions to avoid re-splitting elements.


In bin/standalone-new.sh line 101:
      eval "${JAVA}" -cp "${JBOSS_HOME}/bin/launcher.jar" org.wildfly.core.launcher.StandaloneEntry $@ \"&\"
                                                                                                    ^-- SC2068: Double quote array expansions to avoid re-splitting elements.


In bin/standalone-new.sh line 118:
            SIGNAL=$(expr "${WAIT_STATUS}" - 128)
                     ^--^ SC2003: expr is antiquated. Consider rewriting this using $((..)), ${} or [[ ]].

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2003 -- expr is antiquated. Consider rewr...
`